### PR TITLE
add Atrium to libraries.json

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -417,6 +417,21 @@
   {
     "github": "robstoll/atrium",
     "category": "Test",
-    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/"
-  }
+    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/atrium-fluent-en_GB/"
+  },
+  {
+    "github": "robstoll/atrium",
+    "category": "Test",
+    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/atrium-fluent-en_GB-android/"
+  },
+  {
+    "github": "robstoll/atrium",
+    "category": "Test",
+    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/atrium-fluent-en_GB-android-js/"
+  },
+  {
+    "github": "robstoll/atrium",
+    "category": "Test",
+    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/atrium-fluent-en_GB-android-common/"
+  },
 ]

--- a/libraries.json
+++ b/libraries.json
@@ -413,5 +413,10 @@
     "github": "InsanusMokrassar/TelegramBotAPI",
     "category": "Social",
     "maven": "https://jcenter.bintray.com/com/github/insanusmokrassar/TelegramBotAPI/"
+  },
+  {
+    "github": "robstoll/atrium",
+    "category": "Test",
+    "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/"
   }
 ]

--- a/libraries.json
+++ b/libraries.json
@@ -433,5 +433,5 @@
     "github": "robstoll/atrium",
     "category": "Test",
     "maven": "https://dl.bintray.com/robstoll/tutteli-jars/ch/tutteli/atrium/atrium-fluent-en_GB-android-common/"
-  },
+  }
 ]


### PR DESCRIPTION
This is a follow up to #1 
I finally had time to look into it. 
gradle-metada is actually already published, you must have missed it back in #1. 
For instance:
https://bintray.com/robstoll/tutteli-jars/atrium/0.11.0#files/ch%2Ftutteli%2Fatrium%2Fatrium-api-fluent-en_GB%2F0.11.0